### PR TITLE
Fix uvicorn reload for production

### DIFF
--- a/server.py
+++ b/server.py
@@ -272,4 +272,4 @@ async def chat_endpoint(request: ChatRequest):
 if __name__ == "__main__":
     import uvicorn
     port = int(os.environ.get("PORT", 8080))
-    uvicorn.run("server:app", host="0.0.0.0", port=port, reload=True)
+    uvicorn.run("server:app", host="0.0.0.0", port=port)


### PR DESCRIPTION
Removes reload=True from uvicorn configuration to fix Cloud Run startup