### PR TITLE
Add src/lib to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+//lib/
 lib64/
 parts/
 sdist/

--- a/src/lib/supabase.py
+++ b/src/lib/supabase.py
@@ -1,0 +1,14 @@
+import os
+from supabase import create_client, Client
+from dotenv import load_dotenv
+
+load_dotenv()
+
+url: str = os.environ.get("SUPABASE_URL")
+# Prefer Service Key for backend operations to bypass RLS
+key: str = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_KEY")
+
+if not url or not key:
+    print("Warning: SUPABASE_URL or SUPABASE_KEY/SUPABASE_SERVICE_KEY not found in environment.")
+
+supabase: Client = create_client(url, key)


### PR DESCRIPTION
Fixes ModuleNotFoundError by including src/lib directory that was previously ignored by .gitignore