### PR TITLE
fix: replace BatchSpanProcessor with SimpleSpanProcessor to fix asyncio crash on Python 3.11

### DIFF
--- a/server.py
+++ b/server.py
@@ -25,7 +25,7 @@ sys.path.append(os.path.join(os.getcwd(), 'src'))
 # OpenTelemetry Imports
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, ConsoleSpanExporter
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
@@ -33,7 +33,7 @@ from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 trace.set_tracer_provider(TracerProvider())
 tracer = trace.get_tracer(__name__)
 trace.get_tracer_provider().add_span_processor(
-    BatchSpanProcessor(ConsoleSpanExporter())
+    SimpleSpanProcessor(ConsoleSpanExporter())
 )
 
 from src.agent.middleware import check_rate_limit


### PR DESCRIPTION
O BatchSpanProcessor do OpenTelemetry cria uma thread de background que conflita com o event loop do Python 3.11 durante o startup, causando RuntimeError: list changed size during iteration. Substituído por SimpleSpanProcessor (síncrono, sem threads).